### PR TITLE
ability to disable compression

### DIFF
--- a/gelfling.js
+++ b/gelfling.js
@@ -18,6 +18,7 @@ function Gelfling(host, port, options) {
   this.defaults = options.defaults || {}
   this.errHandler = options.errHandler || console.error
   this.keepAlive = options.keepAlive
+  this.compress = options.compress == null ? true : options.compress
 }
 
 Gelfling.prototype.send = function(data, callback) {
@@ -56,7 +57,13 @@ Gelfling.prototype.close = function() {
 Gelfling.prototype.encode = function(msg, callback) {
   if (callback == null) callback = function() {}
   var that = this
-  zlib.gzip(new Buffer(JSON.stringify(msg)), function(err, compressed) {
+  var buffer = new Buffer(JSON.stringify(msg));
+
+  if(!this.compress){
+    return callback(null, this.split(buffer));
+  }
+
+  zlib.gzip(buffer, function(err, compressed) {
     if (err) return callback(err)
     callback(null, that.split(compressed))
   })

--- a/gelfling.js
+++ b/gelfling.js
@@ -57,11 +57,10 @@ Gelfling.prototype.close = function() {
 Gelfling.prototype.encode = function(msg, callback) {
   if (callback == null) callback = function() {}
   var that = this
-  var buffer = new Buffer(JSON.stringify(msg));
+  var buffer = new Buffer(JSON.stringify(msg))
 
-  if(!this.compress){
-    return callback(null, this.split(buffer));
-  }
+  if(!this.compress)
+    return callback(null, this.split(buffer))
 
   zlib.gzip(buffer, function(err, compressed) {
     if (err) return callback(err)


### PR DESCRIPTION
When sending 1000+ messages second, the zlib library leaks memory pretty bad. I've tried re-writing encode to use zlib.createGzip and chunk directly instead of using split method, but no solution works. Graylog supports uncompressed messages, and because we are on a lan, no need to compress.