### PR TITLE
Fix double-callback on DNS resolution error

### DIFF
--- a/gelfling.js
+++ b/gelfling.js
@@ -23,7 +23,7 @@ function Gelfling(host, port, options) {
 Gelfling.prototype.send = function(data, callback) {
   if (callback == null) callback = function() {}
   if (Buffer.isBuffer(data)) data = [data]
-  var udpClient, remaining, i, self = this
+  var udpClient, remaining, i, self = this, cbDone = false
 
   if (!Array.isArray(data))
     return this.encode(this.convert(data), function(err, chunks) {
@@ -42,7 +42,10 @@ Gelfling.prototype.send = function(data, callback) {
   function checkDone(err) {
     if (err || --remaining === 0) {
       if (!self.keepAlive) udpClient.close()
-      callback(err)
+      if (!cbDone) {
+        cbDone = true;
+        callback(err)
+      }
     }
   }
   for (i = 0; i < data.length; i++)


### PR DESCRIPTION
In case the DNS resolution fails and the data is so big that it's split into multiple UDP package, the `send` method double-callbacks which break Writable stream implementation built on top [gelf-stream](https://www.npmjs.com/package/gelf-stream) for example, making it throw an `cb is not a function` error. Fix that by checking whether the callback was called already or not.

Here's a test case:

``` javascript
"use strict";
var bunyan = require('bunyan');
var gelfStream = require('gelf-stream');

var gelf = function() {
    var impl = gelfStream.forBunyan('this_will_not_resolve', '12123', {});
    impl.on('error', function() {
        // Ignore, can't do anything, let's hope other streams will succeed
    });
    // Convert the 'gelf' logger type to a real logger
    return {
        type: 'raw',
        stream: impl,
        level: 'info'
    };
};

var logger = bunyan.createLogger({
    name: "myapp",
    streams: [
        gelf()
    ]
});

var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
var text = '';
while (text.length < 1600) {
    text += possible.charAt(Math.floor(Math.random() * possible.length));
}

process.stdin.on('data', function () {
    console.log('SEND');
    logger.info(text);
});
```
